### PR TITLE
Some copy editing.

### DIFF
--- a/guide/cicd_101_guide.md
+++ b/guide/cicd_101_guide.md
@@ -1,21 +1,21 @@
 # Intro to CI/CD Workshop
 
-This document will walk through implementing a simple CI/CD pipeline into a codebase using [CircleCI](https://circleci.com/)
+This document will walk through implementing a simple CI/CD pipeline into a codebase using [CircleCI](https://circleci.com/).
 The following will be demonstrated:
 
-- Integrating CircleCI with a Github project
-- A unittest for a python flask application
+- Integrating CircleCI with a GitHub project
+- A unittest for a Python Flask application
 - Implementing a CI/CD pipeline in the codebase using a CircleCI config file in the project
-- Build a Docker image
+- Building a Docker image
 - Deploy the Docker image to [Docker Hub](https://hub.docker.com)
 
 ## Prerequisites
 
 Before you get started you'll need to have these things:
 
-- [Github Account](https://github.com/join)
+- [GitHub Account](https://github.com/join)
 - [CircleCI](https://circleci.com/signup/) account
-- Docker Hub account](https://hub.docker.com)
+- [Docker Hub account](https://hub.docker.com)
 - Fork then clone the [cicd-101-workshop repo](https://github.com/ariv3ra/cicd-101-workshop) locally
 
 <!--  
@@ -28,10 +28,11 @@ Before you get started you'll need to have these things:
 
 ## CircleCI: Add Project
 
-In order for the CircleCI platform to integrate with projects it must have access to your codebase. In this section demonstrate how to give CircleCI access to a project on Github via the CircleCi dashboard.
+In order for the CircleCI platform to integrate with projects it must have access to your codebase. In this section demonstrate how to give CircleCI access to a project on GitHub via the CircleCI Dashboard.
 
-- Login to the [dashboard](http://circleci.com/vcs-authorize/)
+- Login to the [Dashboard](http://circleci.com/vcs-authorize/)
 - Click the **Add Project** icon on the left menu
+- Choose the appropriate GitHub org from the dropdown in the top left
 - Find the `cicd-101-workshop` project in the list
 - Click the corresponding **Set Up Project** button on the right 
 


### PR DESCRIPTION
Most of this PR is just copy editing. The one real change is I added a step to the "CircleCI: Add Project" section. If they already have a CircleCI account, when they go to the Dashboard, the current org will be whatever they last looked at on CircleCI. Not necessarily the one they forked your repo to. Also, in the rare case they fork your repo to an org and not their username, the current org would also be wrong. This steps helps with that.